### PR TITLE
workaround for clang: clang may treat 64-bit struct as unaligned

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -26,7 +26,7 @@ namespace yakushima {
  * so it can't declare default constructor. Therefore, it should use init function to
  * initialize before using this class object.
  */
-class node_version64_body {
+class alignas(sizeof(std::uint64_t)) node_version64_body {
 public:
     using vinsert_delete_type = std::uint32_t;
     using vsplit_type = std::uint32_t;


### PR DESCRIPTION
clang++ (of LLVM 10, 11, 14) でビルドすると 64-bit サイズの struct / class に対する atomic 操作が (align されていないとみなされて) 効率の良いコードを生成しない問題に対するワークアラウンドです。

Issue: https://github.com/project-tsurugi/tsurugi-issues/issues/279