### PR TITLE
remove unnecessary loop in gc

### DIFF
--- a/include/garbage_collection.h
+++ b/include/garbage_collection.h
@@ -33,7 +33,7 @@ public:
 
         while (!node_container_.empty()) {
             std::tuple<Epoch, base_node*> elem;
-            while (!node_container_.try_pop(elem)) continue;
+            if (!node_container_.try_pop(elem)) { continue; }
             delete std::get<gc_target_index>(elem); // NOLINT
         }
 
@@ -48,7 +48,7 @@ public:
 
         while (!value_container_.empty()) {
             std::tuple<Epoch, void*, std::size_t, std::align_val_t> elem;
-            while (!value_container_.try_pop(elem)) continue;
+            if (!value_container_.try_pop(elem)) { continue; }
             ::operator delete(std::get<gc_target_index>(elem),
                               std::get<gc_target_size_index>(elem),
                               std::get<gc_target_align_index>(elem));
@@ -87,7 +87,7 @@ public:
         // for container
         while (!node_container_.empty()) {
             std::tuple<Epoch, base_node*> elem;
-            while (!node_container_.try_pop(elem)) continue;
+            if (!node_container_.try_pop(elem)) { continue; }
             if (std::get<gc_epoch_index>(elem) >= gc_epoch) {
                 cache_node_container_ = elem;
                 return;


### PR DESCRIPTION
キューに対する try_popをwhileで繰り返し、失敗した場合に continueするコードが何箇所かにありました。おそらく本来の意図はcontinueで外側のwhileへ戻ることだと思うのでwhileをifに変更してそのように動くようにしました。

同様のコードが下の方 
https://github.com/project-tsurugi/yakushima/blob/e112fe77d7a343f4745109a32966b6e60bd60a35/include/garbage_collection.h#L115 にもあってこちらはifを使っているのでそれにあわせています。

扱っているキューは複数スレッドからpushされますがpopするのはシングルスレッドのようなので、whileのままでも問題はないのかもしれませんが、あえてwhileである必要もないのでifがいいと思います。