### PR TITLE
fix the way to quit recursion when max_size is specified in scan()

### DIFF
--- a/include/scan_helper.h
+++ b/include/scan_helper.h
@@ -320,6 +320,9 @@ retry:
                 clean_up_tuple_list_nvc();
                 goto retry; // NOLINT
             }
+            if (max_size != 0 && tuple_list.size() >= max_size) {
+                return status::OK_SCAN_END;
+            }
         } else {
             auto in_range = [&full_key, &tuple_list, &vp, &node_version_vec,
                              &v_at_fb, &node_version_ptr, &tuple_pushed_num,

--- a/test/scan/scan_max_num_test.cpp
+++ b/test/scan/scan_max_num_test.cpp
@@ -58,4 +58,58 @@ TEST_F(st, one_border) { // NOLINT
     ASSERT_EQ(tuple_list.size(), 3);
     ASSERT_EQ(leave(token), status::OK);
 }
+
+TEST_F(st, reach_limit_on_border) { // NOLINT
+    //                    aaaaaaaabbbbbbbb
+    std::string_view k11("0000000111111111");
+    std::string_view k12("0000000111111112");
+    std::string_view k13("0000000111111113");
+    std::string_view k21("0000000222222221");
+    std::string_view k22("0000000222222222");
+    std::string_view k23("0000000222222223");
+    std::string_view k31("0000000333333331");
+    std::string_view k32("0000000333333332");
+    std::string_view k33("0000000333333333");
+    std::string v("v");
+    Token token{};
+    std::vector<std::tuple<std::string, char*, std::size_t>> tuple_list{};
+    ASSERT_EQ(enter(token), status::OK);
+    ASSERT_EQ(status::OK, put(token, test_storage_name, k11, v.data(), v.size()));
+    ASSERT_EQ(status::OK, put(token, test_storage_name, k12, v.data(), v.size()));
+    ASSERT_EQ(status::OK, put(token, test_storage_name, k13, v.data(), v.size()));
+    ASSERT_EQ(status::OK, put(token, test_storage_name, k21, v.data(), v.size()));
+    ASSERT_EQ(status::OK, put(token, test_storage_name, k22, v.data(), v.size()));
+    ASSERT_EQ(status::OK, put(token, test_storage_name, k23, v.data(), v.size()));
+    ASSERT_EQ(status::OK, put(token, test_storage_name, k31, v.data(), v.size()));
+    ASSERT_EQ(status::OK, put(token, test_storage_name, k32, v.data(), v.size()));
+    ASSERT_EQ(status::OK, put(token, test_storage_name, k33, v.data(), v.size()));
+    ASSERT_EQ(status::OK,
+              scan<char>(test_storage_name, "", scan_endpoint::INF, "",
+                         scan_endpoint::INF, tuple_list, nullptr));
+    ASSERT_EQ(tuple_list.size(), 9);
+    ASSERT_EQ(status::OK,
+              scan<char>(test_storage_name, "", scan_endpoint::INF, "",
+                         scan_endpoint::INF, tuple_list, nullptr, 0));
+    ASSERT_EQ(tuple_list.size(), 9);
+    ASSERT_EQ(status::OK,
+              scan<char>(test_storage_name, "", scan_endpoint::INF, "",
+                         scan_endpoint::INF, tuple_list, nullptr, 1));
+    ASSERT_EQ(tuple_list.size(), 1);
+    EXPECT_EQ(std::get<0>(tuple_list.at(0)), k11);
+    ASSERT_EQ(status::OK,
+              scan<char>(test_storage_name, "", scan_endpoint::INF, "",
+                         scan_endpoint::INF, tuple_list, nullptr, 2));
+    ASSERT_EQ(tuple_list.size(), 2);
+    EXPECT_EQ(std::get<0>(tuple_list.at(0)), k11);
+    EXPECT_EQ(std::get<0>(tuple_list.at(1)), k12);
+    ASSERT_EQ(status::OK,
+              scan<char>(test_storage_name, "", scan_endpoint::INF, "",
+                         scan_endpoint::INF, tuple_list, nullptr, 3));
+    ASSERT_EQ(tuple_list.size(), 3);
+    EXPECT_EQ(std::get<0>(tuple_list.at(0)), k11);
+    EXPECT_EQ(std::get<0>(tuple_list.at(1)), k12);
+    EXPECT_EQ(std::get<0>(tuple_list.at(2)), k13);
+    ASSERT_EQ(leave(token), status::OK);
+}
+
 } // namespace yakushima::testing


### PR DESCRIPTION
scan で max_size を指定した場合の処理の抜け方に問題があり、border node の子供で 上限に達して抜けてきても、再帰を打ち切らずに 次の再帰を開始してしまっていました。
このため スキャン結果 tuple_list の max_size 要素以降に、ツリー構造に依存したとびとびのエントリの値が追加されていく現象が起きていました。

これを正しく打ち切るように修正します。

案件: project-tsurugi/tsurugi-issues#999