### PR TITLE
build: add build option `BUILD_STRICT`

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,6 +8,9 @@ on:
       os:
         type: string
         default: 'ubuntu-22.04'
+      cmake_build_option:
+        type: string
+        default: ''
 
 jobs:
   Test:
@@ -36,14 +39,14 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local -DPERFORMANCE_TOOLS=OFF ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local -DPERFORMANCE_TOOLS=OFF ${{ inputs.cmake_build_option }} ..
           cmake --build . --target all --clean-first
 
       - name: CMake_Build_Release
         run: |
           mkdir build_release
           cd build_release
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local -DPERFORMANCE_TOOLS=OFF ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local -DPERFORMANCE_TOOLS=OFF ${{ inputs.cmake_build_option }} ..
           cmake --build . --target all --clean-first
 
       - name: CTest_Debug
@@ -92,7 +95,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local -DPERFORMANCE_TOOLS=OFF ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/.local -DPERFORMANCE_TOOLS=OFF ${{ inputs.cmake_build_option }} ..
 
       - name: Clang-Tidy
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(BUILD_BENCHMARK "Build benchmark programs" ON)
 option(BUILD_TESTS "Build test programs" ON)
 option(BUILD_DOCUMENTS "Build documents" ON)
 option(BUILD_ONLY_WD_TEST "Build only working directory about test for dev" OFF)
+option(BUILD_STRICT "build with option strictly determine of success" ON)
 
 option(ENABLE_SANITIZER "enable sanitizer on debug build" ON)
 option(ENABLE_UB_SANITIZER "enable undefined behavior sanitizer on debug build" ON)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ available options:
 default : `ON`
 * `-DBUILD_DOCUMENTS=OFF` : never build documents by doxygen<br>
 default : `ON`
+* `-DBUILD_STRICT=OFF` - don't treat compile warnings as build errors<br>
+default : `ON`
 * `-DCMAKE_INSTALL_PREFIX=/path/to/yakushima/installed`
 * `-DFORMAT_FILES_WITH_CLANG_FORMAT_BEFORE_EACH_BUILD=ON` : use formatting for source files<br>
 default : `OFF`

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -46,6 +46,11 @@ if (ENABLE_JEMALLOC)
 endif ()
 
 function(set_compile_options target_name)
-  target_compile_options(${target_name}
-  PRIVATE -Wall -Wextra -Werror)
+  if (BUILD_STRICT)
+    target_compile_options(${target_name}
+      PRIVATE -Wall -Wextra -Werror)
+  else()
+    target_compile_options(${target_name}
+      PRIVATE -Wall -Wextra)
+  endif()
 endfunction(set_compile_options)


### PR DESCRIPTION
Introduced a new `BUILD_STRICT` CMake option to enable strict compilation settings ( with `-Werror` ).
By default, this option is enabled but can be turned off by `-DBUILD_STRICT=OFF`

This PR also enable to specify CMake build option on CI Workflow for workflow_dispatch via `inputs.cmake_build_option`
